### PR TITLE
Coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+coverage/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,3 @@
+sudo: false
 before_script: make
-script: make test
+script: make coverage

--- a/Makefile
+++ b/Makefile
@@ -19,4 +19,7 @@ minify:
 		-o $(minified) \
 		http://closure-compiler.appspot.com/compile
 
-.PHONY: install test minify
+coverage: test
+	@./node_modules/.bin/codecov
+
+.PHONY: install test minify coverage

--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,7 @@ install:
 	@npm install
 
 test:
-	@./node_modules/.bin/mocha-phantomjs \
-		test/test.html
+	@./node_modules/.bin/karma start conf/karma.conf.js
 
 minify:
 	@echo "> Minifying..."

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# draggable.js [![Build Status](https://travis-ci.org/gtramontina/draggable.js.png)](https://travis-ci.org/gtramontina/draggable.js) [![Bitdeli Badge](https://d2weczhvl823v0.cloudfront.net/gtramontina/draggable.js/trend.png)](https://bitdeli.com/free "Bitdeli Badge")
+# draggable.js [![Build Status](https://travis-ci.org/gtramontina/draggable.js.png)](https://travis-ci.org/gtramontina/draggable.js) [![codecov.io](https://codecov.io/github/gtramontina/draggable.js/coverage.svg?branch=master)](https://codecov.io/github/gtramontina/draggable.js?branch=master) [![Bitdeli Badge](https://d2weczhvl823v0.cloudfront.net/gtramontina/draggable.js/trend.png)](https://bitdeli.com/free "Bitdeli Badge")
 ##### Make your DOM elements draggagle easily
 
 ### Examples

--- a/conf/karma.conf.js
+++ b/conf/karma.conf.js
@@ -40,6 +40,18 @@ module.exports = function(config) {
     // possible values: 'dots', 'progress'
     // available reporters: https://npmjs.org/browse/keyword/karma-reporter
     reporters: ['progress', 'coverage'],
+    
+    
+    // configure the coverage reporter 
+    coverageReporter: {
+      // Specify a reporter type.
+      type: 'lcov',
+      dir: 'coverage/',
+      subdir: function(browser) {
+        // normalization process to keep a consistent browser name accross different OS
+        return browser.toLowerCase().split(/[ /-]/)[0]; // output the results into: './coverage/phantomjs/'
+      }
+    },
 
 
     // web server port

--- a/conf/karma.conf.js
+++ b/conf/karma.conf.js
@@ -25,19 +25,21 @@ module.exports = function(config) {
 
     // list of files to exclude
     exclude: [
+      '!draggable.js'
     ],
 
 
     // preprocess matching files before serving them to the browser
     // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
     preprocessors: {
+      'draggable.js': ['coverage']
     },
 
 
     // test results reporter to use
     // possible values: 'dots', 'progress'
     // available reporters: https://npmjs.org/browse/keyword/karma-reporter
-    reporters: ['progress'],
+    reporters: ['progress', 'coverage'],
 
 
     // web server port
@@ -54,7 +56,7 @@ module.exports = function(config) {
 
 
     // enable / disable watching file and executing tests whenever any file changes
-    autoWatch: true,
+    autoWatch: false,
 
 
     // start these browsers

--- a/conf/karma.conf.js
+++ b/conf/karma.conf.js
@@ -15,7 +15,7 @@ module.exports = function(config) {
 
     // list of files / patterns to load in the browser
     files: [
-      'http://code.jquery.com/jquery-2.0.3.min.js',
+      'https://cdn.jsdelivr.net/jquery/2.1/jquery.min.js',
       'http://rawgithub.com/LearnBoost/expect.js/master/index.js',
       'http://rawgithub.com/tmcw/happen/master/happen.js',
       'draggable.js',

--- a/conf/karma.conf.js
+++ b/conf/karma.conf.js
@@ -1,0 +1,73 @@
+// Karma configuration
+// Generated on Fri Dec 11 2015 17:24:07 GMT+0100 (Romance Standard Time)
+
+module.exports = function(config) {
+  config.set({
+
+    // base path that will be used to resolve all patterns (eg. files, exclude)
+    basePath: '..',
+
+
+    // frameworks to use
+    // available frameworks: https://npmjs.org/browse/keyword/karma-adapter
+    frameworks: ['mocha'],
+
+
+    // list of files / patterns to load in the browser
+    files: [
+      'http://code.jquery.com/jquery-2.0.3.min.js',
+      'http://rawgithub.com/LearnBoost/expect.js/master/index.js',
+      'http://rawgithub.com/tmcw/happen/master/happen.js',
+      'draggable.js',
+      'test/draggable.test.js'
+    ],
+
+
+    // list of files to exclude
+    exclude: [
+    ],
+
+
+    // preprocess matching files before serving them to the browser
+    // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
+    preprocessors: {
+    },
+
+
+    // test results reporter to use
+    // possible values: 'dots', 'progress'
+    // available reporters: https://npmjs.org/browse/keyword/karma-reporter
+    reporters: ['progress'],
+
+
+    // web server port
+    port: 9876,
+
+
+    // enable / disable colors in the output (reporters and logs)
+    colors: true,
+
+
+    // level of logging
+    // possible values: config.LOG_DISABLE || config.LOG_ERROR || config.LOG_WARN || config.LOG_INFO || config.LOG_DEBUG
+    logLevel: config.LOG_WARN,
+
+
+    // enable / disable watching file and executing tests whenever any file changes
+    autoWatch: true,
+
+
+    // start these browsers
+    // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
+    browsers: ['PhantomJS'],
+
+
+    // Continuous Integration mode
+    // if true, Karma captures browsers, runs the tests and exits
+    singleRun: true,
+
+    // Concurrency level
+    // how many browser should be started simultanous
+    concurrency: Infinity
+  })
+}

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "url": "https://github.com/gtramontina/draggable.js"
   },
   "scripts": {
-    "test": "karma start conf/karma.conf.js"
+    "test": "make test"
   },
   "main": "draggable.js",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -17,16 +17,11 @@
   },
   "main": "draggable.js",
   "devDependencies": {
-    "karma": "^0.13.15",
-    "karma-chrome-launcher": "^0.2.2",
-    "karma-coverage": "^0.5.3",
-    "karma-firefox-launcher": "^0.1.7",
-    "karma-ie-launcher": "^0.2.0",
-    "karma-mocha": "^0.2.1",
-    "karma-opera-launcher": "^0.3.0",
-    "karma-phantomjs-launcher": "^0.2.1",
-    "karma-safari-launcher": "^0.1.1",
-    "mocha-phantomjs": "3.1",
+    "codecov": "1.0",
+    "karma": "0.13",
+    "karma-coverage": "0.5",
+    "karma-mocha": "0.2",
+    "karma-phantomjs-launcher": "0.2",
     "phantomjs": "1.9"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,16 +1,32 @@
 {
-  "name"              : "draggable.js",
-  "version"           : "1.0.1",
-  "description"       : "Make your DOM elements draggable easily",
-  "keywords"          : [ "microjs", "drag", "draggable" ],
-  "author"            : "Guilherme J. Tramontina <guilherme.tramontina@gmail.com>",
-  "repository"        : {
-    "type"            : "git",
-    "url"             : "https://github.com/gtramontina/draggable.js"
+  "name": "draggable.js",
+  "version": "1.0.1",
+  "description": "Make your DOM elements draggable easily",
+  "keywords": [
+    "microjs",
+    "drag",
+    "draggable"
+  ],
+  "author": "Guilherme J. Tramontina <guilherme.tramontina@gmail.com>",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gtramontina/draggable.js"
+  },
+  "scripts": {
+    "test": "karma start conf/karma.conf.js"
   },
   "main": "draggable.js",
-  "devDependencies"   : {
-    "phantomjs"       : "1.9",
-    "mocha-phantomjs" : "3.1"
+  "devDependencies": {
+    "karma": "^0.13.15",
+    "karma-chrome-launcher": "^0.2.2",
+    "karma-coverage": "^0.5.3",
+    "karma-firefox-launcher": "^0.1.7",
+    "karma-ie-launcher": "^0.2.0",
+    "karma-mocha": "^0.2.1",
+    "karma-opera-launcher": "^0.3.0",
+    "karma-phantomjs-launcher": "^0.2.1",
+    "karma-safari-launcher": "^0.1.1",
+    "mocha-phantomjs": "3.1",
+    "phantomjs": "1.9"
   }
 }

--- a/test/test.html
+++ b/test/test.html
@@ -4,7 +4,7 @@
   <title>Draggable.js</title>
   <link rel="stylesheet" href="http://rawgithub.com/visionmedia/mocha/master/mocha.css" />
 
-  <script src="http://code.jquery.com/jquery-2.0.3.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/jquery/2.1/jquery.min.js"></script>
   <script src="http://rawgithub.com/LearnBoost/expect.js/master/index.js"></script>
   <script src="http://rawgithub.com/tmcw/happen/master/happen.js"></script>
   <script src="http://rawgithub.com/visionmedia/mocha/master/mocha.js" charset="UTF-8"></script>


### PR DESCRIPTION
There is many ways to get `lcov` data. [Karma](http://karma-runner.github.io/0.13/index.html) is the simplest. Even though it is not as lean as the mocha-phantomjs, istanbul + hook, it is a lot easier to reason with one config file.

I tried the mocha-phantomjs, istanbul + [mocha-phantomjs-istanbul](https://github.com/willembult/mocha-phantomjs-istanbul) combination. But while, I can easily setup make to output an instrumented test file when draggable.js changes, via istanbul. I can not for the life in me, get any instrumented code feedback back to istanbul, when mocha-phantomjs runs. So no coverage data.

[Here is another approach with a custom hook](https://blog.engineyard.com/2015/measuring-clientside-javascript-test-coverage-with-istanbul), instead of mocha-phantomjs-istanbul.

But all these choices fade in contrast to the ease of Karma. And I think Karma has a more active developer community + some of the unused features could be useful tomorrow. Like automated tests in real browsers while developing.
